### PR TITLE
Fix page number i TOC for list of figs, tables, etc

### DIFF
--- a/front-back-matter/contents.tex
+++ b/front-back-matter/contents.tex
@@ -1,18 +1,26 @@
 %!TEX root = ../thesis.tex
 
-\cleardoublepage\tableofcontents
+\cleardoublepage
+\phantomsection
 \addcontentsline{toc}{chapter}{\contentsname}
+\tableofcontents
 
-\cleardoublepage\listoffigures
+\cleardoublepage
+\phantomsection
 \addcontentsline{toc}{chapter}{\listfigurename}
+\listoffigures
 
-\cleardoublepage\listoftables
+\cleardoublepage
+\phantomsection
 \addcontentsline{toc}{chapter}{\listtablename}
+\listoftables
 
 % Here add additional list of things,
 % such as \listoflistings
-\cleardoublepage\listoflistings
+\cleardoublepage
+\phantomsection
 \addcontentsline{toc}{chapter}{\listlistingname}
+\listoflistings
 
 
 \modernthesisprintacronyms{}


### PR DESCRIPTION
If e.g. the "List of Figures" section is more than one page long, the TOC will show the page number of the last page of the section. The same goes for the other "List of [...]". This PR fixes it.